### PR TITLE
割り勘計算部分をリファクタリング

### DIFF
--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
@@ -63,7 +63,7 @@ extension DutchTreatCalculator {
     }
 
     //MARK: 差額調整
-    func adjustDifference(in memberPayments: MemberPayments) -> MemberPayments {
+    private func adjustDifference(in memberPayments: MemberPayments) -> MemberPayments {
 
         let difference = memberPayments.differenceFromBillingAmount()
         if difference.isZero() {

--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
@@ -55,7 +55,7 @@ extension DutchTreatCalculator {
     //MARK: 差額調整
     func adjustDifference(in memberPayments: MemberPayments) -> MemberPayments {
 
-        let totalPaymentAmount = memberPayments.totalPaymemtAmount()
+        let totalPaymentAmount = memberPayments.totalPaymentAmount()
 
         let difference = billingAmount - totalPaymentAmount;
         if difference.isZero() {

--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
@@ -40,16 +40,26 @@ extension DutchTreatCalculator {
     //MARK: 割り勘
     func splitBill() -> MemberPayments {
 
-        let totalWeight = partyMembers.totalWeight(with: paymentLevelSpecifics);
+        let paymentAmountsByLevel = _computedPaymentAmountsByLevel()
 
         let memberPayments = partyMembers.map() { member -> MemberPayment in
-
-            let weight = paymentLevelSpecifics.weight(for: member)
-            let roundedAmount = (billingAmount * weight / totalWeight).rounded(by: specifiedRounding)
-            return MemberPayment(member: member, paymentAmount: roundedAmount)
+            let appliedPaymentAmount = paymentAmountsByLevel[member.paymentLevel]!                  //NOTE: 計算済みの金額を適用するだけ
+            return MemberPayment(member: member, paymentAmount: appliedPaymentAmount)
         }
 
         return adjustDifference(in: MemberPayments(rawMemberPayments: memberPayments, billingAmount: billingAmount))
+    }
+
+    //MARK: 割り勘計算
+    private func _computedPaymentAmountsByLevel() -> [PaymentLevel: PaymentAmount] {
+
+        let weightsByLevel = paymentLevelSpecifics.weightsByLevel
+        let totalWeight = partyMembers.totalWeight(with: paymentLevelSpecifics);
+
+        let levelAndPayment = weightsByLevel.map() { level, weight in
+                (level, (billingAmount * weight / totalWeight).rounded(by: specifiedRounding)) }    //SPEC: 割り勘の計算式
+
+        return Dictionary(uniqueKeysWithValues: levelAndPayment)
     }
 
     //MARK: 差額調整

--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/DutchTreatCalculator.swift
@@ -55,9 +55,7 @@ extension DutchTreatCalculator {
     //MARK: 差額調整
     func adjustDifference(in memberPayments: MemberPayments) -> MemberPayments {
 
-        let totalPaymentAmount = memberPayments.totalPaymentAmount()
-
-        let difference = billingAmount - totalPaymentAmount;
+        let difference = memberPayments.differenceFromBillingAmount()
         if difference.isZero() {
             return memberPayments;
         }

--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/result/MemberPayments.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/result/MemberPayments.swift
@@ -29,7 +29,7 @@ extension MemberPayments {
 //MARK: 計算
 extension MemberPayments {
 
-    func totalPaymemtAmount() -> TotalPaymentAmount {
+    func totalPaymentAmount() -> TotalPaymentAmount {
 
         let total = _rawMemberPayments
                 .map { $0.paymentAmount }

--- a/study_DDD_DutchTreat_Swift/src/domain/model/calculation/result/MemberPayments.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/calculation/result/MemberPayments.swift
@@ -29,7 +29,11 @@ extension MemberPayments {
 //MARK: 計算
 extension MemberPayments {
 
-    func totalPaymentAmount() -> TotalPaymentAmount {
+    func differenceFromBillingAmount() -> DifferenceAmount {
+        _billingAmount - totalPaymentAmount();
+    }
+
+    private func totalPaymentAmount() -> TotalPaymentAmount {
 
         let total = _rawMemberPayments
                 .map { $0.paymentAmount }

--- a/study_DDD_DutchTreat_Swift/src/domain/model/monetary/payment/factor/PaymentLevelSpecifics.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/monetary/payment/factor/PaymentLevelSpecifics.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct PaymentLevelSpecifics {
 
-    private var weightsByLevel: [PaymentLevel : Weight] = [:]
+    let weightsByLevel: [PaymentLevel : Weight]
 }
 
 //MARK: 初期化
@@ -18,10 +18,13 @@ extension PaymentLevelSpecifics {
 
     init(moreWeight: Weight, standardWeight: Weight, lessWeight: Weight) {
 
-        weightsByLevel[.more] = moreWeight
-        weightsByLevel[.standard] = standardWeight
-        weightsByLevel[.less] = lessWeight
+        var weightsByLevel_ = [PaymentLevel : Weight]()
 
+        weightsByLevel_[.more] = moreWeight
+        weightsByLevel_[.standard] = standardWeight
+        weightsByLevel_[.less] = lessWeight
+
+        weightsByLevel = weightsByLevel_
         _validate()
     }
 

--- a/study_DDD_DutchTreat_Swift/src/domain/model/monetary/payment/factor/Weight.swift
+++ b/study_DDD_DutchTreat_Swift/src/domain/model/monetary/payment/factor/Weight.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Weight {
+struct Weight: Hashable {
 
     var value: Int
 }

--- a/study_DDD_DutchTreat_SwiftTests/test/domain/model/party/DrinkingPartyTest.swift
+++ b/study_DDD_DutchTreat_SwiftTests/test/domain/model/party/DrinkingPartyTest.swift
@@ -208,7 +208,7 @@ class DrinkingPartyTest: XCTestCase {
             print("actual=\n\(memberPayments)")
             print("expected=\(expected)")
 
-            XCTAssertTrue(billingAmount == memberPayments.totalPaymemtAmount(), "支払総額が請求金額と同じになっていること")
+            XCTAssertTrue(billingAmount == memberPayments.totalPaymentAmount(), "支払総額が請求金額と同じになっていること")
 
             memberPayments.forEach { (actual) in
 

--- a/study_DDD_DutchTreat_SwiftTests/test/domain/model/party/DrinkingPartyTest.swift
+++ b/study_DDD_DutchTreat_SwiftTests/test/domain/model/party/DrinkingPartyTest.swift
@@ -208,7 +208,7 @@ class DrinkingPartyTest: XCTestCase {
             print("actual=\n\(memberPayments)")
             print("expected=\(expected)")
 
-            XCTAssertTrue(billingAmount == memberPayments.totalPaymentAmount(), "支払総額が請求金額と同じになっていること")
+            XCTAssertTrue(memberPayments.differenceFromBillingAmount().isZero(), "支払総額が請求金額と同じになっていること")
 
             memberPayments.forEach { (actual) in
 


### PR DESCRIPTION
* 請求金額と支払金額との差額計算を 計算器 → MemberPayments に移動
* 計算をメンバー毎ではなく支払レベル毎に実施するように修正
    かとじゅんさんからブレークスルーがあったというお話をきいて対応してみた。
    メンバー毎に全メンバーについて計算していたのが、支払レベル数（少なめ／普通／多め の3つ）だけで済むようになった。